### PR TITLE
Added "app"/"application" connection string parameter for easier clie…

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -6,8 +6,8 @@ import (
 )
 
 type credentials struct {
-	user, pwd, host, database, mirrorHost, compatibility string
-	maxPoolSize, lockTimeout                             int
+	user, pwd, host, database, mirrorHost, compatibility, appName string
+	maxPoolSize, lockTimeout                                      int
 }
 
 // NewCredentials fills credentials stusct from connection string
@@ -30,6 +30,8 @@ func NewCredentials(connStr string) *credentials {
 				crd.pwd = value
 			case "failover partner", "failover_partner", "mirror", "mirror_host", "mirror host":
 				crd.mirrorHost = value
+			case "app", "application", "application name", "application_name":
+				crd.appName = value
 			case "max pool size", "max_pool_size":
 				if i, err := strconv.Atoi(value); err == nil {
 					crd.maxPoolSize = i

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -77,3 +77,18 @@ func TestParseConnectionStringEqualsInValue(t *testing.T) {
 		assert.Equal(t, 1000, crd.lockTimeout)
 	}
 }
+
+func TestParseConnectionStringApplicationName(t *testing.T) {
+	validConnStrings := []string{
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;app=myAppName",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;application=myAppName",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;application name=myAppName",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;application_name=myAppName",
+	}
+	expectedAppName := "myAppName"
+
+	for _, connStr := range validConnStrings {
+		credentials := NewCredentials(connStr)
+		assert.Equal(t, expectedAppName, credentials.appName)
+	}
+}


### PR DESCRIPTION
Added an "application" connection string parameter for more convenient client identification on the database side.

You can also use "app", "application name", "application_name" as a parameter name