### PR TITLE
Added "conn timeout" connection string parameter, to replace hardcode…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -39,7 +39,6 @@ import (
  }
 
  static void my_dblogin(LOGINREC* login, char* username, char* password, char* appname) {
-  dbsetlogintime(10);
   dberrhandle(err_handler);
   dbmsghandle(msg_handler);
   DBSETLUSER(login, username);
@@ -50,6 +49,10 @@ import (
 
  static void my_dblogin_setdb(LOGINREC* login, char* dbname) {
   DBSETLDBNAME(login, dbname);
+ }
+
+ static void my_dblogin_settimeout(LOGINREC* login, int timeout) {
+  dbsetlogintime(timeout);
  }
 
  static void my_setlversion(LOGINREC* login) {
@@ -214,6 +217,11 @@ func (conn *Conn) getDbProc() (*C.DBPROCESS, error) {
 	cappname := C.CString(conn.appName)
 	defer C.free(unsafe.Pointer(cappname))
 	C.my_dblogin(login, cuser, cpwd, cappname)
+
+	// If a connection timeout is specified in the connection string, add it to the login packet
+	if conn.connTimeout > 0 {
+		C.my_dblogin_settimeout(login, C.int(conn.connTimeout))
+	}
 
 	// If a database name is specified in the connection string,
 	// add the DB name to the login packet.

--- a/credentials.go
+++ b/credentials.go
@@ -5,15 +5,17 @@ import (
 	"strings"
 )
 
+const defaultConnTimeoutSec = 10
+
 type credentials struct {
 	user, pwd, host, database, mirrorHost, compatibility, appName string
-	maxPoolSize, lockTimeout                                      int
+	maxPoolSize, lockTimeout, connTimeout                int
 }
 
 // NewCredentials fills credentials stusct from connection string
 func NewCredentials(connStr string) *credentials {
 	parts := strings.Split(connStr, ";")
-	crd := &credentials{maxPoolSize: 100}
+	crd := &credentials{maxPoolSize: 100, connTimeout: defaultConnTimeoutSec}
 	for _, part := range parts {
 		kv := strings.SplitN(part, "=", 2)
 		if len(kv) == 2 {
@@ -41,6 +43,10 @@ func NewCredentials(connStr string) *credentials {
 			case "lock timeout", "lock_timeout":
 				if i, err := strconv.Atoi(value); err == nil {
 					crd.lockTimeout = i
+				}
+			case "conn timeout", "conn_timeout", "connection timeout", "connection_timeout":
+				if i, err := strconv.Atoi(value); err == nil {
+					crd.connTimeout = i
 				}
 			}
 

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,6 +1,7 @@
 package freetds
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,4 +92,27 @@ func TestParseConnectionStringApplicationName(t *testing.T) {
 		credentials := NewCredentials(connStr)
 		assert.Equal(t, expectedAppName, credentials.appName)
 	}
+}
+
+func TestParseConnectionStringConnTimeout(t *testing.T) {
+	expectedTimeout := defaultConnTimeoutSec + 5
+	validConnStrings := []string{
+		fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;conn timeout=%d", expectedTimeout),
+		fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;conn_timeout=%d", expectedTimeout),
+		fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;connection timeout=%d", expectedTimeout),
+		fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;connection_timeout=%d", expectedTimeout),
+	}
+
+	for _, connStr := range validConnStrings {
+		credentials := NewCredentials(connStr)
+		assert.Equal(t, expectedTimeout, credentials.connTimeout)
+	}
+}
+
+func TestParseConnectionStringDefaultConnTimeout(t *testing.T) {
+	expectedTimeout := defaultConnTimeoutSec
+	validConnString := fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;conn timeout=%d", expectedTimeout)
+
+	credentials := NewCredentials(validConnString)
+	assert.Equal(t, expectedTimeout, credentials.connTimeout)
 }


### PR DESCRIPTION
Added "conn timeout" connection string parameter instead of hardcode value. Now it is possible to fine-tune the client

You can also use "conn_timeout", "connection timeout", "connection_timeout" as a parameter name