### PR TITLE
Added "tds timeout" connection string parameter

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -8,8 +8,8 @@ import (
 const defaultConnTimeoutSec = 10
 
 type credentials struct {
-	user, pwd, host, database, mirrorHost, compatibility, appName string
-	maxPoolSize, lockTimeout, connTimeout                int
+	user, pwd, host, database, mirrorHost, compatibility, appName, tdsVersion string
+	maxPoolSize, lockTimeout, connTimeout                                     int
 }
 
 // NewCredentials fills credentials stusct from connection string
@@ -48,8 +48,9 @@ func NewCredentials(connStr string) *credentials {
 				if i, err := strconv.Atoi(value); err == nil {
 					crd.connTimeout = i
 				}
+			case "tds version", "tds_version":
+				crd.tdsVersion = value
 			}
-
 		}
 	}
 	return crd

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -116,3 +116,16 @@ func TestParseConnectionStringDefaultConnTimeout(t *testing.T) {
 	credentials := NewCredentials(validConnString)
 	assert.Equal(t, expectedTimeout, credentials.connTimeout)
 }
+
+func TestParseConnectionStringTDSVersion(t *testing.T) {
+	expectedVersion := "myVersion"
+	validConnStrings := []string{
+		fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;tds_version=%s", expectedVersion),
+		fmt.Sprintf("host=myhost;database=mydb;user=myuser;pwd=mypwd;tds version=%s", expectedVersion),
+	}
+
+	for _, connStr := range validConnStrings {
+		credentials := NewCredentials(connStr)
+		assert.Equal(t, expectedVersion, credentials.tdsVersion)
+	}
+}


### PR DESCRIPTION
Added "tds timeout"/"tds_version" connection string parameter, to enable fine-tuning of TDS protocol